### PR TITLE
hugo: mark broken on x86_64-darwin specifically

### DIFF
--- a/pkgs/development/python-modules/google-re2/default.nix
+++ b/pkgs/development/python-modules/google-re2/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "google-re2";
-  version = "0.2.20220401";
+  version = "0.2.20220601";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-v3G+MvFV8gq9LJqj/zrtlTjRm0ZNxTh0UdQSPiwFHY4=";
+    hash = "sha256-zBCYPcqgsyYKTNHAfHrcH6aWfbz6zJwajxHkwRjHeQU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/gpsoauth/default.nix
+++ b/pkgs/development/python-modules/gpsoauth/default.nix
@@ -7,14 +7,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.0";
+  version = "1.0.1";
   pname = "gpsoauth";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1c4d6a980625b8ab6f6f1cf3e30d9b10a6c61ababb2b60bfe4870649e9c82be0";
+    sha256 = "sha256-wxLyvrNwT3QQHGLCxaIFdRG7OJpECMpynE+lgAGtFk0=";
   };
 
   propagatedBuildInputs = [ pycryptodomex requests ];


### PR DESCRIPTION
###### Description of changes

In 37c633f7ae518456af1f3064bd5c386e2de92c37, several packages were marked broken on stdenv.Darwin, some of which seem to be broken specifically due to the older SDK used for x86_64-darwin. This is one of those packages, and in this case specifically, go1.17 [dropped support for 10.12](https://go.dev/doc/go1.17#ports) last year. 

Related: #169478, #101229
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
